### PR TITLE
fix: CONTINUE_ON_ERROR option usage on errors

### DIFF
--- a/bin/createRelease.js
+++ b/bin/createRelease.js
@@ -27,7 +27,7 @@ async function main () {
 
     console.log('Release created: ' + release.html_url)
   } catch (error) {
-    handleError(error)
+    handleError(error, config.continueOnError)
   }
 }
 


### PR DESCRIPTION
 Avoid `process.exit(1)` if CONTINUE_ON_ERROR is setted to `true`

<img width="1376" alt="Screen Shot 2020-08-13 at 18 31 21" src="https://user-images.githubusercontent.com/5944629/90189268-3a85ce00-dd93-11ea-8637-57e534d21043.png">
