### PR TITLE
fix: sanitize tagResponse list to prevent exception errors

### DIFF
--- a/lib/github.js
+++ b/lib/github.js
@@ -17,9 +17,14 @@ class GitHubService {
    */
   async getPreviousTag (targetTag) {
     const tagResponse = await this.gh.repos.listTags(this.repo)
+    const semanticVersionRegex = /^v([0-9]|[1-9][0-9]*)\.([0-9]|[1-9][0-9]*)\.([0-9]|[1-9][0-9]*)(?:-([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?(?:\+[0-9A-Za-z-]+)?$/
+
+    const validTagList = tagResponse.data
+      .map(tag => tag.name)
+      .filter(tag => semanticVersionRegex.test(tag))
 
     return semver
-      .sort(tagResponse.data.map(tag => tag.name))
+      .sort(validTagList)
       .reverse()
       .find(tag => semver.lt(tag, targetTag))
   }

--- a/lib/github.test.js
+++ b/lib/github.test.js
@@ -21,6 +21,46 @@ describe('getPreviousTag', () => {
     })
   })
 
+  it('should returns previous tag when invalid tag is provided', async () => {
+    const listTags = jest.fn().mockResolvedValue({
+      data: [
+        { name: 'v0.5.0' },
+        { name: 'v.0.5.1' },
+        { name: 'v.0.5.2' },
+        { name: 'v.0.5.3' }
+      ]
+    })
+    const gh = new GitHubService({ repos: { listTags } }, 'foo', 'bar')
+
+    const res = await gh.getPreviousTag('v1.0.0')
+
+    expect(res).toEqual('v0.5.0')
+    expect(listTags).toHaveBeenCalledWith({
+      owner: 'foo',
+      repo: 'bar'
+    })
+  })
+
+  it('should returns undefined when only invalid tag is provided', async () => {
+    const listTags = jest.fn().mockResolvedValue({
+      data: [
+        { name: 'v.0.5.0' },
+        { name: 'v.0.5.1' },
+        { name: 'v.0.5.2' },
+        { name: 'v.0.5.3' }
+      ]
+    })
+    const gh = new GitHubService({ repos: { listTags } }, 'foo', 'bar')
+
+    const res = await gh.getPreviousTag('v1.0.0')
+
+    expect(res).toEqual(undefined)
+    expect(listTags).toHaveBeenCalledWith({
+      owner: 'foo',
+      repo: 'bar'
+    })
+  })
+
   it('returns undefined when there aren\'t any tags', async () => {
     const listTags = jest.fn().mockResolvedValue({
       data: []


### PR DESCRIPTION
## Jira card

THC-344

## Description

No projeto [escale-components](https://github.com/escaletech/escale-components) havia sido gerado todas as versões usando outro padrão de `tags`, dessa maneira quando fomos adotar o releaser e o orb no circle ci [tivemos erros para publicar o release do projeto](https://app.circleci.com/pipelines/github/escaletech/escale-components/57/workflows/5a68a720-aeec-4aab-93cb-bc3048d54bdd/jobs/100), já que na regra do orb, a comparação de versão é feita em todas as tags do projeto.

Para prevenir que esse erro acontecesse, foi necessário filtrar a resposta de tags do github apenas com tags semanticamente corretas, dessa maneira, a comparação é feita corretamente.

Caso exista alguma outra alternativa para contornar o problema inicial, é bem vida também. :D


## Checklist:

- [x] Follow guidelines
- [x] Self-reviewed
- [x] No errors or warnings
- [x] Added unit tests
- [x] Tests passing
